### PR TITLE
Find Python 2 dynamically

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -74,11 +74,21 @@ YOUTUBE_DL_EXE = find_executable(
     ],
     '--version',
 )
+PYTHON2_EXE = find_executable(
+    "Python",
+    re.compile(r"^Python 2\."),
+    [
+        "python",
+        "python2",
+    ]
+)
 
 if not WPULL_EXE:
     raise Exception("No usable Wpull found.")
 if not YOUTUBE_DL_EXE:
     raise Exception("No usable youtube-dl found.")
+if not PYTHON2_EXE:
+    raise Exception("No usable Python found.")
 
 
 ###########################################################################
@@ -173,7 +183,7 @@ class DeduplicateWarcExtProc(ExternalProcess):
 class DeduplicateWarcExtProcArgs(object):
     def realize(self, item):
         dedup_args = [
-            'python',
+            PYTHON2_EXE,
             '-u', # no output buffering
             'dedupe.py',
             '%(item_dir)s/%(warc_file_base)s.warc.gz' % item,


### PR DESCRIPTION
Modern and up-to-date systems (e.g. Gentoo, Arch) have Python 3 as the default version, i.e. calling `python` executes Python 3. On these systems, we need to call `python2`.
Some very old systems (e.g. warrior 2) have no `/usr/bin/python2` symlink. On these systems, we need to call `python`.

The output of `python -V` has been like `Python 5.6.7` since at least Python 2.3.0 (I haven't checked earlier versions), so it should be safe to rely on it.