### PR TITLE
Ignore characters that we can't encode

### DIFF
--- a/warcio/statusandheaders.py
+++ b/warcio/statusandheaders.py
@@ -145,7 +145,7 @@ headers = {2})".format(self.protocol, self.statusline, headers_str)
         return string
 
     def to_bytes(self, filter_func=None):
-        return self.to_str(filter_func).encode('iso-8859-1') + b'\r\n'
+        return self.to_str(filter_func).encode('iso-8859-1', 'ignore') + b'\r\n'
 
 
 #=================================================================


### PR DESCRIPTION
```
Deduplicating digest sha1:3I42H3S6NNFQ2MSVX7XZKYAYSCX5QBYJ, url https://static.xx.fbcdn.net/rsrc.php/v3icqO4/y_/l/it_IT/3d-bkgrd-16-2x.jpg
Deduplicating digest sha1:3I42H3S6NNFQ2MSVX7XZKYAYSCX5QBYJ, url https://static.xx.fbcdn.net/rsrc.php/v3ikjC4/yE/l/it_IT/PEG.js
Deduplicating digest sha1:3I42H3S6NNFQ2MSVX7XZKYAYSCX5QBYJ, url https://static.xx.fbcdn.net/rsrc.php/v3i3TB4/yJ/l/zh_CN/Photo.jpg
Deduplicating digest sha1:3I42H3S6NNFQ2MSVX7XZKYAYSCX5QBYJ, url https://static.xx.fbcdn.net/rsrc.php/v3i_854/yI/l/zh_CN/%E6%A0%BC%E5%BC%8F%EF%BC%9A.PNG%E3%80%81.JPG%E3%80%81.JPEG
Traceback (most recent call last):
  File "dedupe.py", line 81, in <module>
    process(filename_in, filename_out)
  File "dedupe.py", line 71, in process
    writer.write_record(record)
  File "/data/data/projects/newsgrabber-731f176/warcio/warcwriter.py", line 325, in write_record
    self._write_warc_record(self.out, record)
  File "/data/data/projects/newsgrabber-731f176/warcio/warcwriter.py", line 225, in _write_warc_record
    self._set_header_buff(record)
  File "/data/data/projects/newsgrabber-731f176/warcio/warcwriter.py", line 217, in _set_header_buff
    headers_buff = record.http_headers.to_bytes(self.header_filter)
  File "/data/data/projects/newsgrabber-731f176/warcio/statusandheaders.py", line 148, in to_bytes
    return self.to_str(filter_func).encode('iso-8859-1') + b'\r\n'
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe6 in position 179: ordinal not in range(128)
Process DeduplicateWarcExtProc returned exit code 1 for Item newsbuddy:warrior_5_1530383124.14
Failed DeduplicateWarcExtProc for Item newsbuddy:warrior_5_1530383124.14`
```