### PR TITLE
Check for the existence of a custom attribute instead of the unreliable path comparison

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -18,10 +18,7 @@ import warcio
 from warcio.archiveiterator import ArchiveIterator
 from warcio.warcwriter import WARCWriter
 
-if not warcio.__file__ == os.path.join(os.getcwd(), 'warcio', '__init__.pyc'):
-    print('Warcio was not imported correctly.')
-    print('Location: ' + warcio.__file__ + '.')
-    sys.exit(1)
+assert hasattr(warcio, 'ATWARCIO'), 'warcio was not imported correctly. Location: ' + warcio.__file__
 
 try:
     import requests

--- a/warcio/__init__.py
+++ b/warcio/__init__.py
@@ -1,1 +1,1 @@
-print('hi')
+ATWARCIO = True


### PR DESCRIPTION
The path comparison only works on CPython 2 and only from the second run because the `.pyc` file doesn't exist on the first run.